### PR TITLE
fix: Add role-based redirect logic to Index page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,11 +8,23 @@ const Index = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // Check if user is already logged in
+    // Check if user is already logged in and redirect based on role
     const checkAuth = async () => {
       const { data: { session } } = await supabase.auth.getSession();
       if (session) {
-        navigate("/dashboard");
+        // Fetch user role to determine redirect
+        const { data } = await supabase
+          .from("user_roles")
+          .select("role")
+          .eq("user_id", session.user.id)
+          .maybeSingle();
+
+        const userRole = data?.role || "user";
+        if (userRole === "admin") {
+          navigate("/dashboard");
+        } else {
+          navigate("/portfolio");
+        }
       }
     };
     checkAuth();


### PR DESCRIPTION
Previously, the Index page always redirected logged-in users to /dashboard, which caused a routing conflict with DashboardWrapper's role-based logic. Regular users would be redirected to /dashboard then immediately to /portfolio, causing unnecessary redirects and potential UI flicker.

Now the Index page checks the user's role and redirects appropriately:
- Admins → /dashboard
- Regular users → /portfolio

Fixes #9